### PR TITLE
Replace references to Chrome

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,6 +1,6 @@
 ### Contributors
 
-The Zhongwen Chrome extension was written by Christian Schiller with
+The Zhongwen browser extension was written by Christian Schiller with
 contributions from the following people:
 
 * Todd Rudick (http://rikaixul.mozdev.org/)

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 /*
  Zhongwen - A Chinese-English Pop-Up Dictionary
  Copyright (C) 2010-2019 Christian Schiller
- https://chrome.google.com/extensions/detail/kkmlkkjojmombglmlpbpapmhcaljjkde
+ https://github.com/cschiller/zhongwen
 
  ---
 

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 /*
  Zhongwen - A Chinese-English Pop-Up Dictionary
  Copyright (C) 2010-2019 Christian Schiller
- https://chrome.google.com/extensions/detail/kkmlkkjojmombglmlpbpapmhcaljjkde
+ https://github.com/cschiller/zhongwen
 
  ---
 

--- a/dict.js
+++ b/dict.js
@@ -1,7 +1,7 @@
 /*
  Zhongwen - A Chinese-English Pop-Up Dictionary
  Copyright (C) 2019 Christian Schiller
- https://chrome.google.com/extensions/detail/kkmlkkjojmombglmlpbpapmhcaljjkde
+ https://github.com/cschiller/zhongwen
 
  ---
 

--- a/js/options.js
+++ b/js/options.js
@@ -1,7 +1,7 @@
 /*
  Zhongwen - A Chinese-English Pop-Up Dictionary
  Copyright (C) 2010-2019 Christian Schiller
- https://chrome.google.com/extensions/detail/kkmlkkjojmombglmlpbpapmhcaljjkde
+ https://github.com/cschiller/zhongwen
  */
 
 'use strict';

--- a/js/wordlist.js
+++ b/js/wordlist.js
@@ -1,7 +1,7 @@
 /*
  Zhongwen - A Chinese-English Pop-Up Dictionary
  Copyright (C) 2010-2019 Christian Schiller
- https://chrome.google.com/extensions/detail/kkmlkkjojmombglmlpbpapmhcaljjkde
+ https://github.com/cschiller/zhongwen
  */
 
 let wordList = localStorage['wordlist'];

--- a/options.html
+++ b/options.html
@@ -7,10 +7,10 @@
     <script src="js/options.js" type="text/javascript"></script>
 </head>
 <body>
-<h2>Options for the Zhongwen Chrome Extension</h2>
+<h2>Options for the Zhongwen Browser Extension</h2>
 
 On this page you can set your personal preferences for the Zhongwen
-Chinese Pop-up Dictionary Chrome extension.
+Chinese Pop-up Dictionary browser extension.
 
 <p>
     <input id="save" style="margin-top: 1em;" type="submit" value="Save these settings"/>


### PR DESCRIPTION
I'm very happy that you make your extension available for both Chrome and Firefox. 
This PR changes "Zhongwen Chrome Extension" to "Zhongwen Browser Extension" and replaces links to the Chrome store with ones to GitHub.