### PR TITLE
Fix csslint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "scripts": {
     "lint": "eslint --fix *.js js/options.js js/wordlist.js",
-    "csslint": "stylelint css/popup*.css css/toneColors*.css css/wordlist.css"
+    "csslint": "stylelint css/content.css css/wordlist.css"
   }
 }


### PR DESCRIPTION
Fixes the `csslint` script to include the `content.css` that was added in #18.