### PR TITLE
Adjust capitalization of context menus

### DIFF
--- a/background.js
+++ b/background.js
@@ -98,7 +98,7 @@ function activateExtension(tabId, showHelp) {
 
     chrome.contextMenus.create(
         {
-            title: 'Open word list',
+            title: 'Open Word List',
             onclick: function () {
                 let url = chrome.runtime.getURL('/wordlist.html');
                 let tabID = tabIDs['wordlist'];
@@ -132,7 +132,7 @@ function activateExtension(tabId, showHelp) {
     );
     chrome.contextMenus.create(
         {
-            title: 'Show help in new tab',
+            title: 'Show Help in New Tab',
             onclick: function () {
                 let url = chrome.runtime.getURL('/help.html');
                 let tabID = tabIDs['help'];


### PR DESCRIPTION
Use Title Case for the context menu entries to match the native style.
This change is only for the Firefox branch as long the two are separate.

![image](https://user-images.githubusercontent.com/2564094/60779005-f46d2e00-a0ed-11e9-86e9-e4548a390b7e.png)
![image](https://user-images.githubusercontent.com/2564094/60779022-018a1d00-a0ee-11e9-93fd-51f39d9de9c7.png)
