### PR TITLE
Reset line-height in the pop-up

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -17,6 +17,7 @@
   font-size: 12px;
   font-family: Tahoma, Geneva, sans-serif;
   visibility: visible;
+  line-height: initial;
 }
 
 #zhongwen-window {


### PR DESCRIPTION
Fixes #26 by restoring the line height in the pop-up to the initial value.
![image](https://user-images.githubusercontent.com/2564094/68537431-4500cc00-0318-11ea-9cd7-0a52b3d21e8e.png)
