### PR TITLE
Fix lost focus on page load due to false equivalency check

### DIFF
--- a/content.js
+++ b/content.js
@@ -743,7 +743,7 @@ function highlightMatch(doc, rangeStartNode, rangeStartOffset, matchLen, selEndL
 
 function clearHighlight() {
 
-    if (selText === null) {
+    if (!selText) {
         return;
     }
 


### PR DESCRIPTION
Focus was being cleared via selection.empty() since clearHighlight didn't early-exit on first run, due to selText being undefined rather than null. Coerce selText to Boolean to catch this case.

Focus is still lost when character highlighting is done, which seems like unintended behaviour. To make that better I'd suggest storing the carat position and using Selection.collapse(ToEnd|ToStart).