### PR TITLE
Added option to disable highlighting text when hovering

### DIFF
--- a/background.js
+++ b/background.js
@@ -64,7 +64,8 @@ let zhongwenOptions = window.zhongwenOptions = {
     zhuyin: localStorage['zhuyin'] || 'no',
     grammar: localStorage['grammar'] || 'yes',
     simpTrad: localStorage['simpTrad'] || 'classic',
-    toneColorScheme: localStorage['toneColorScheme'] || 'standard'
+    toneColorScheme: localStorage['toneColorScheme'] || 'standard',
+    disableHighlight: localStorage['disableHighlight'] || 'no'
 };
 
 function activateExtension(tabId, showHelp) {

--- a/content.js
+++ b/content.js
@@ -729,7 +729,7 @@ function hidePopup() {
 }
 
 function highlightMatch(doc, rangeStartNode, rangeStartOffset, matchLen, selEndList) {
-    if (!selEndList || selEndList.length === 0) return;
+    if (!selEndList || selEndList.length === 0 || config.disableHighlight === 'yes') return;
 
     let selEnd;
     let offset = rangeStartOffset + matchLen;

--- a/js/options.js
+++ b/js/options.js
@@ -36,6 +36,9 @@ function loadVals() {
 
     const skritterTLD = localStorage['skritterTLD'] || 'com';
     document.querySelector(`input[name="skritterTLD"][value="${skritterTLD}"]`).checked = true;
+
+    const disableHighlight = localStorage['disableHighlight'] || 'no';
+    document.querySelector('#disableHighlight').checked = disableHighlight === 'yes';
 }
 
 function setPopupColor(popupColor) {
@@ -99,6 +102,9 @@ window.addEventListener('load', () => {
         input.addEventListener('change',
             () => setOption('skritterTLD', input.getAttribute('value')));
     });
+
+    document.querySelector('#disableHighlight').addEventListener('change',
+        (event) => setBooleanOption('disableHighlight', event.target.checked));
 });
 
 loadVals();

--- a/options.html
+++ b/options.html
@@ -158,6 +158,16 @@
             <label class="custom-control-label" for="skritterTLDcn">skritter.cn</label>
         </div>
     </div>
+
+    <div class="form-group mb-4">
+        <label>This setting allows you to turn off the text
+            highlight around entries which can make selecting text easier.</label>
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" id="disableHighlight" name="disableHighlight">
+            <label class="custom-control-label" for="disableHighlight">Turn off word highlighting.</label>
+        </div>
+    </div>
+
 </div>
 <script src="js/options.js" type="text/javascript"></script>
 </body>


### PR DESCRIPTION
Sometimes when I'm trying to highlight and select a lot of text that is Chinese, the zhongwen extension can sort of steal focus which can make selecting text somewhat inconvenient. I've added an checkbox in the Options menu that lets you disable the highlight but still preserves all the normal hover-over functionality of the extension.

It's a bit difficult to describe the change, so I went ahead and made a quick video to demonstrate the change.
[Demo](https://youtu.be/36fs_3SoxhA)

Appreciate it if you would pull this change in.