### PR TITLE
Deal with Ou  pinyin tonemarks

### DIFF
--- a/content.js
+++ b/content.js
@@ -994,9 +994,10 @@ function tonify(vowels, tone) {
     let html = '';
     let text = '';
 
-    if (vowels === 'ou') {
-        html = 'o' + tones[tone] + 'u';
-        text = 'o' + utones[tone] + 'u';
+	if (vowels === 'ou' || vowels === "Ou") {
+		let o = vowels[0];
+        html = o + tones[tone] + 'u';
+        text = o + utones[tone] + 'u';
     } else {
         let tonified = false;
         for (let i = 0; i < vowels.length; i++) {


### PR DESCRIPTION
i noticed that words like Ouzhou, 歐洲, when capitalized dont get the tonemark on the O but on the u, that seems wrong to me. (and wiktionary seems to agree) this pr hopefully fixes that
cheers
