### PR TITLE
Add customizable clipboard format

### DIFF
--- a/content.js
+++ b/content.js
@@ -144,8 +144,14 @@ function onKeyDown(keyDown) {
             triggerSearch();
             break;
 
-        case 67: // 'c'
-            copyToClipboard(getTextForClipboard());
+        case 67: // 'c' or 'C'
+            if (keyDown.shiftKey) {
+                // 'C' — copy all entries
+                copyToClipboard(getTextForClipboard(false));
+            } else {
+                // 'c' — copy first entry only
+                copyToClipboard(getTextForClipboard(true));
+            }
             break;
 
         case 66: // 'b'
@@ -788,10 +794,31 @@ function isVisible() {
     return popup && popup.style.display !== 'none';
 }
 
-function getTextForClipboard() {
+/**
+ * Formats a single search result entry using the configured clipboard format string.
+ * Placeholders: {simplified}, {traditional}, {pinyin}, {definition}
+ */
+function formatEntry(entry, format) {
+    return format
+        .replace(/\\t/g, '\t')
+        .replace(/\\n/g, '\n')
+        .replace(/\{simplified\}/g, entry[0] || '')
+        .replace(/\{traditional\}/g, entry[1] || '')
+        .replace(/\{pinyin\}/g, entry[2] || '')
+        .replace(/\{definition\}/g, entry[3] || '');
+}
+
+function getTextForClipboard(firstOnly) {
+    if (savedSearchResults.length === 0) return '';
+
+    console.log(config)
+    console.log(config.clipboardFormat)
+    const format = config.clipboardFormat;
+    const entries = firstOnly ? [savedSearchResults[0]] : savedSearchResults;
+
     let result = '';
-    for (let i = 0; i < savedSearchResults.length; i++) {
-        result += savedSearchResults[i].slice(0, -1).join('\t');
+    for (let i = 0; i < entries.length; i++) {
+        result += formatEntry(entries[i], format);
         result += '\n';
     }
     return result;

--- a/js/options.js
+++ b/js/options.js
@@ -41,6 +41,101 @@ function loadVals() {
     document.querySelector(`input[name="saveToWordList"][value="${config.saveToWordList}"]`).checked = true;
 
     document.querySelector(`input[name="skritterTLD"][value="${config.skritterTLD}"]`).checked = true;
+
+    // Clipboard format
+    loadClipboardFormat();
+}
+
+function loadClipboardFormat() {
+    const section = document.querySelector('#clipboardFormatSection');
+    const format = localStorage['clipboardFormat'] || '{simplified}\t{traditional}\t{pinyin}\t{definition}';
+
+    // Predefined format presets: add/remove/reorder here to update the options page
+    const presets = [
+        {
+            id: 'clipboardFormatFull',
+            label: 'Full entry (tab-separated)',
+            value: '{simplified}\t{traditional}\t{pinyin}\t{definition}',
+        },
+        {
+            id: 'clipboardFormatSimplifiedPinyinDef',
+            label: 'Simplified only',
+            value: '{simplified}\t{pinyin}\t{definition}',
+        },
+        {
+            id: 'clipboardFormatTraditionalPinyinDef',
+            label: 'Traditional only',
+            value: '{traditional}\t{pinyin}\t{definition}',
+        },
+        {
+            id: 'clipboardFormatHanziPinyin',
+            label: 'Hanzi + Pinyin',
+            value: '{simplified} {pinyin}',
+        },
+    ];
+
+    // Build the section HTML
+    let html = '';
+
+    // Render preset radio buttons
+    const matchesPreset = presets.some(p => p.value === format);
+    for (const preset of presets) {
+        const checked = preset.value === format ? 'checked' : '';
+        const escapedValue = preset.value.replace(/"/g, '&quot;');
+        html += `
+            <div class="custom-control custom-radio">
+                <input type="radio" id="${preset.id}" name="clipboardFormat"
+                       class="custom-control-input" value="${escapedValue}" ${checked}>
+                <label class="custom-control-label" for="${preset.id}">
+                    ${preset.label}: <code>${preset.value}</code>
+                </label>
+            </div>
+        `;
+    }
+
+    // Custom format radio + text input
+    const escapedFormat = format.replace(/"/g, '&quot;');
+    html += `
+        <div class="custom-control custom-radio">
+            <input type="radio" id="clipboardFormatCustom" name="clipboardFormat"
+                   class="custom-control-input" value="custom" ${!matchesPreset ? 'checked' : ''}>
+            <label class="custom-control-label" for="clipboardFormatCustom">Custom format:</label>
+        </div>
+        <input type="text" class="form-control mt-2" id="clipboardFormatCustomInput"
+               placeholder="{simplified} {pinyin} - {definition}"
+               value="${!matchesPreset ? escapedFormat : ''}"
+               style="max-width: 500px; font-family: monospace;">
+        <small class="form-text text-muted">Use <code>\\t</code> for tab and <code>\\n</code> for newline.</small>
+    `;
+
+    section.innerHTML += html;
+
+    // Attach event listeners to dynamically created elements
+
+    // Preset radio buttons
+    section.querySelectorAll('input[name="clipboardFormat"]').forEach((input) => {
+        input.addEventListener('change', () => {
+            const value = input.value;
+            if (value === 'custom') {
+                const customInput = section.querySelector('#clipboardFormatCustomInput');
+                if (customInput.value) {
+                    setOption('clipboardFormat', customInput.value);
+                }
+            } else {
+                setOption('clipboardFormat', value);
+            }
+        });
+    });
+
+    // Custom text input: auto-selects "Custom" radio when typed into
+    const customInput = section.querySelector('#clipboardFormatCustomInput');
+    customInput.addEventListener('input', () => {
+        const customRadio = section.querySelector('#clipboardFormatCustom');
+        customRadio.checked = true;
+        if (customInput.value) {
+            setOption('clipboardFormat', customInput.value);
+        }
+    });
 }
 
 function setPopupColor(popupColor) {

--- a/options.html
+++ b/options.html
@@ -154,6 +154,15 @@
         </div>
     </div>
 
+    <div class="form-group mb-4" id="clipboardFormatSection">
+        <label>Clipboard copy format (press <kbd>c</kbd> for first entry, <kbd>Shift+C</kbd> for all entries)</label>
+        <p class="text-muted small">
+            Available placeholders: <code>{simplified}</code>, <code>{traditional}</code>,
+            <code>{pinyin}</code>, <code>{definition}</code>
+        </p>
+        <!-- Dynamically populated by options.js -->
+    </div>
+
     <div class="form-group mb-4">
         <label>URL used for adding words to your <a href="https://skritter.com" target="_blank">Skritter</a>
             queue (Skritter subscription required)</label>


### PR DESCRIPTION
This PR adds the ability to customize the copy clipboard functionality by having presets and having custom clipboard format using placeholders

Available placeholders: `{simplified}, {traditional}, {pinyin}, {definition}`

 Full entry (tab-separated): `{simplified} {traditional} {pinyin} {definition}`
- Simplified only: `{simplified} {pinyin} {definition}`
- Traditional only: `{traditional} {pinyin} {definition}`
- Hanzi + Pinyin: `{simplified} {pinyin}`
- Custom format

**Screenshot**
<img width="843" height="341" alt="Screenshot 2026-07-21 at 18 25 40" src="https://github.com/user-attachments/assets/7fcc39d1-af47-440e-9dd2-ca30c9a23879" />

e.g. before, hovering over `埋头苦干` and pressing `c` would copy all of this:

```
  埋头苦干  埋頭苦幹  mái tóu kǔ gàn  to bury oneself in work (idiom); to be engrossed in work ◆ to make an all-out effort ◆ up to the neck in work
  埋头  埋頭  mái tóu to immerse oneself in ◆ engrossed in sth ◆ to lower the head (e.g. to avoid rain) ◆ countersunk (of screws,
  rivets etc)
  埋 埋 mái  to bury
  埋 埋 mán  used in 埋怨[man2 yuan4]
```

With the *Simplified only: `{simplified} {pinyin} {definition}`* option selected, this would be copied to the clipboard:

```
埋头苦干   mái tóu kǔ gàn  to bury oneself in work (idiom); to be engrossed in work ◆ to make an all-out effort ◆ up to the neck in work
```
