### PR TITLE
feat: Check for CC-CEDICT updates dynamically

### DIFF
--- a/background.js
+++ b/background.js
@@ -50,6 +50,7 @@
 
 import { ZhongwenDictionary } from './dict.js';
 import './js/config.js';
+import { loadDictData, refreshDictData, getDictStatus } from './js/dict-loader.js';
 
 let dict;
 
@@ -274,19 +275,6 @@ async function loadDictionary() {
     return new ZhongwenDictionary(wordDict, wordIndex, grammarKeywords, vocabKeywords);
 }
 
-async function loadDictData() {
-    let wordDict = fetch(chrome.runtime.getURL(
-        "data/cedict_ts.u8")).then(r => r.text());
-    let wordIndex = fetch(chrome.runtime.getURL(
-        "data/cedict.idx")).then(r => r.text());
-    let grammarKeywords = fetch(chrome.runtime.getURL(
-        "data/grammarKeywordsMin.json")).then(r => r.json());
-    let vocabKeywords = fetch(chrome.runtime.getURL(
-        "data/vocabularyKeywordsMin.json")).then(r => r.json());
-
-    return Promise.all([wordDict, wordIndex, grammarKeywords, vocabKeywords]);
-}
-
 function lookup(dictionary, text) {
 
     let entry = dictionary.wordSearch(text);
@@ -400,3 +388,24 @@ chrome.runtime.onMessage.addListener(function (message) {
     }
 });
 
+// Dictionary management messages (from options page)
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+    if (message.type === "getDictStatus") {
+        getDictStatus().then((status) => {
+            sendResponse(status);
+        });
+        return true;
+    }
+    if (message.type === "refreshDict") {
+        refreshDictData().then((data) => {
+            dict = new ZhongwenDictionary(data.wordDict, data.wordIndex, data.grammarKeywords, data.vocabKeywords);
+            return getDictStatus();
+        }).then((status) => {
+            sendResponse({ success: true, status });
+        }).catch((err) => {
+            sendResponse({ success: false, error: String(err) });
+        });
+        return true;
+    }
+    return void 0;
+});

--- a/js/dict-loader.js
+++ b/js/dict-loader.js
@@ -1,0 +1,214 @@
+/**
+ * Dynamic CC-CEDICT dictionary loader.
+ *
+ * Strategy:
+ * 1. Check IndexedDB for a cached dictionary + index.
+ * 2. If cached data exists and is recent enough, use it.
+ * 3. Otherwise, download the latest CEDICT from MDBG, build the index,
+ *    store both in IndexedDB, and return them.
+ * 4. If download fails, fall back to the bundled data shipped with the extension.
+ * 5. User can manually trigger a refresh from the options page.
+ */
+
+const CEDICT_URL = "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.txt.gz";
+const DB_NAME = "zhongwen-dict";
+const DB_VERSION = 1;
+const STORE_NAME = "cedict";
+
+/** How often to auto-refresh the dictionary (7 days in ms) */
+const UPDATE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1e3;
+
+function openDB() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: "id" });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+function getFromDB(db) {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly");
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.get("cedict");
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+function putInDB(db, data) {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readwrite");
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.put(data);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+function buildIndex(dictText) {
+    const indexMap = /* @__PURE__ */ new Map();
+    const lines = dictText.split("\n");
+    let offset = 0;
+    for (const line of lines) {
+        if (line && !line.startsWith("#")) {
+            const match = line.match(/^(\S+)\s+(\S+)\s+/);
+            if (match) {
+                const traditional = match[1];
+                const simplified = match[2];
+                const simpOffsets = indexMap.get(simplified);
+                if (simpOffsets) {
+                    simpOffsets.push(offset);
+                } else {
+                    indexMap.set(simplified, [offset]);
+                }
+                if (traditional !== simplified) {
+                    const tradOffsets = indexMap.get(traditional);
+                    if (tradOffsets) {
+                        tradOffsets.push(offset);
+                    } else {
+                        indexMap.set(traditional, [offset]);
+                    }
+                }
+            }
+        }
+        offset += line.length + 1;
+    }
+    const entries = [];
+    const sortedKeys = [...indexMap.keys()].sort();
+    for (const key of sortedKeys) {
+        entries.push(key + "," + indexMap.get(key).join(","));
+    }
+    return entries.join("\n");
+}
+async function downloadCEDICT() {
+    const response = await fetch(CEDICT_URL);
+    if (!response.ok) {
+        throw new Error(`Failed to download CEDICT: ${response.status} ${response.statusText}`);
+    }
+    const compressedData = await response.arrayBuffer();
+    const ds = new DecompressionStream("gzip");
+    const decompressedStream = new Response(
+        new Blob([compressedData]).stream().pipeThrough(ds)
+    ).text();
+    return decompressedStream;
+}
+
+async function loadBundledDictData() {
+    const [wordDict, wordIndex] = await Promise.all([
+        fetch(chrome.runtime.getURL("data/cedict_ts.u8")).then((r) => r.text()),
+        fetch(chrome.runtime.getURL("data/cedict.idx")).then((r) => r.text())
+    ]);
+    return { wordDict, wordIndex };
+}
+
+async function loadGrammarVocabKeywords() {
+    return await Promise.all([
+        fetch(chrome.runtime.getURL("data/grammarKeywordsMin.json")).then((r) => r.json()),
+        fetch(chrome.runtime.getURL("data/vocabularyKeywordsMin.json")).then((r) => r.json())
+    ]);
+}
+
+export async function getDictStatus() {
+    try {
+        const db = await openDB();
+        const cached = await getFromDB(db);
+        db.close();
+        if (cached) {
+            const entryCount = cached.wordIndex.split("\n").length;
+            return {
+                hasCachedDict: true,
+                cachedTimestamp: cached.timestamp,
+                entryCount
+            };
+        }
+    } catch (dbError) {
+        // IndexedDB not available
+        console.warn("[Zhongwen] IndexedDB unavailable, could not fetch status", dbError);
+    }
+    return {
+        hasCachedDict: false,
+        cachedTimestamp: null,
+        entryCount: null
+    };
+}
+
+/**
+ * Forces a fresh download of CEDICT from MDBG, rebuilds the index,
+ * and stores the result in IndexedDB. Returns the new dict data.
+ * Throws if download fails.
+ */
+export async function refreshDictData() {
+    console.log("[Zhongwen] Downloading latest CEDICT from MDBG...");
+    const wordDict = await downloadCEDICT();
+
+    console.log("[Zhongwen] Building index...");
+    const wordIndex = buildIndex(wordDict);
+
+    // Store in IndexedDB
+    const db = await openDB();
+    await putInDB(db, {
+        id: "cedict",
+        wordDict,
+        wordIndex,
+        timestamp: Date.now()
+    });
+    db.close();
+    console.log("[Zhongwen] CEDICT updated and cached in IndexedDB");
+    const [grammarKeywords, vocabKeywords] = await loadGrammarVocabKeywords();
+    return { wordDict, wordIndex, grammarKeywords, vocabKeywords };
+}
+
+/**
+ * Loads the CC-CEDICT dictionary data, using IndexedDB cache when available,
+ * downloading fresh data from MDBG when needed, and falling back to the
+ * bundled extension data if all else fails.
+ */
+export async function loadDictData() {
+    let wordDict;
+    let wordIndex;
+
+    try {
+        const db = await openDB();
+        const cached = await getFromDB(db);
+        db.close();
+        const now = Date.now();
+
+        if (cached && now - cached.timestamp < UPDATE_INTERVAL_MS) {
+            console.log("[Zhongwen] Using cached CEDICT from IndexedDB");
+            wordDict = cached.wordDict;
+            wordIndex = cached.wordIndex;
+        } else {
+            try {
+                const freshData = await refreshDictData();
+                wordDict = freshData.wordDict;
+                wordIndex = freshData.wordIndex;
+            } catch (downloadError) {
+                console.warn("[Zhongwen] Download failed, using cached or bundled data:", downloadError);
+                if (cached) {
+                    // Use stale cache as fallback
+                    wordDict = cached.wordDict;
+                    wordIndex = cached.wordIndex;
+                } else {
+                    // No cache, fall back to bundled
+                    const bundled = await loadBundledDictData();
+                    wordDict = bundled.wordDict;
+                    wordIndex = bundled.wordIndex;
+                }
+            }
+        }
+    } catch (dbError) {
+        console.warn("[Zhongwen] IndexedDB unavailable, using bundled data", dbError);
+        const bundled = await loadBundledDictData();
+        wordDict = bundled.wordDict;
+        wordIndex = bundled.wordIndex;
+    }
+
+    const [grammarKeywords, vocabKeywords] = await loadGrammarVocabKeywords();
+    return [wordDict, wordIndex, grammarKeywords, vocabKeywords];
+}

--- a/js/options.js
+++ b/js/options.js
@@ -41,6 +41,71 @@ function loadVals() {
     document.querySelector(`input[name="saveToWordList"][value="${config.saveToWordList}"]`).checked = true;
 
     document.querySelector(`input[name="skritterTLD"][value="${config.skritterTLD}"]`).checked = true;
+
+    loadDictStatus();
+}
+
+function loadDictStatus() {
+    const section = document.querySelector('#dictStatusSection');
+
+    // Show loading state
+    section.innerHTML = '<p class="text-muted">Checking dictionary status...</p>';
+
+    chrome.runtime.sendMessage({ type: 'getDictStatus' }, (status) => {
+        renderDictStatus(section, status);
+    });
+}
+
+function renderDictStatus(section, status) {
+    let html = '';
+
+    if (status && status.hasCachedDict) {
+        const date = new Date(status.cachedTimestamp).toLocaleString();
+        html += `
+            <p><strong>Source:</strong> Downloaded from MDBG</p>
+            <p><strong>Last updated:</strong> ${date}</p>
+            <p><strong>Entries:</strong> ~${status.entryCount.toLocaleString()}</p>
+        `;
+    } else {
+        html += `
+            <p><strong>Source:</strong> Bundled with extension</p>
+            <p class="text-muted">No downloaded dictionary cached. Click the button below to download the latest version from MDBG.</p>
+        `;
+    }
+
+    html += `
+        <button id="refreshDictBtn" class="btn btn-primary btn-sm mt-2">
+            ${status && status.hasCachedDict ? 'Check for updates' : 'Download latest CEDICT'}
+        </button>
+        <span id="refreshDictStatus" class="ml-2 text-muted small"></span>
+    `;
+
+    section.innerHTML = html;
+
+    // Attach refresh button handler
+    const btn = document.querySelector('#refreshDictBtn');
+    const statusSpan = document.querySelector('#refreshDictStatus');
+
+    btn.addEventListener('click', () => {
+        btn.disabled = true;
+        btn.textContent = 'Downloading...';
+        statusSpan.textContent = '';
+
+        chrome.runtime.sendMessage({ type: 'refreshDict' }, (response) => {
+            if (response && response.success) {
+                statusSpan.textContent = '✓ Dictionary updated successfully!';
+                statusSpan.className = 'ml-2 text-success small';
+                // Re-render with new status
+                renderDictStatus(section, response.status);
+            } else {
+                const errorMsg = response.error || 'Unknown error';
+                statusSpan.textContent = '✗ Update failed: ' + errorMsg;
+                statusSpan.className = 'ml-2 text-danger small';
+                btn.disabled = false;
+                btn.textContent = 'Retry';
+            }
+        });
+    });
 }
 
 function setPopupColor(popupColor) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Zhongwen: Chinese-English Dictionary",
+  "name": "Zhongwen: Chinese-English Dictionary)",
   "short_name": "Zhongwen",
   "version": "6.3.0",
   "author": "Christian Schiller",
@@ -44,6 +44,9 @@
     "contextMenus",
     "storage",
     "tabs"
+  ],
+  "host_permissions": [
+    "https://www.mdbg.net/*"
   ],
   "commands": {
     "_execute_action": {

--- a/options.html
+++ b/options.html
@@ -168,6 +168,13 @@
             <label class="custom-control-label" for="skritterTLDcn">skritter.cn</label>
         </div>
     </div>
+
+    <h2 class="mb-3">Dictionary</h2>
+
+    <div class="form-group mb-4" id="dictStatusSection">
+        <!-- Dynamically populated by options.js -->
+    </div>
+
 </div>
 <script src="js/config.js" ></script>
 <script src="js/options.js" type="text/javascript"></script>


### PR DESCRIPTION
Zhongwen comes with a bundled CC-CEDICT dictionary which is updated when a new version of the extension is released. I noticed this extension hasn't been updated since April 2025 (version 6.3.0), meaning the bundled dictionary is somewhat stale.

This PR adds functionality to download the latest CC-CEDICT dictionary directly from the [MDBG website](https://www.mdbg.net/chinese/dictionary?page=cc-cedict) and store it in IndexedDB.

Tested with [recent additions on CC-CEDICT](https://cc-cedict.org/editor/editor.php?listchanges_searchuseridmatchtype=2&listchanges_matchwholewordonly=1&start=100&limit=50&handler=ListChanges) like `雙料` and `千足金`

<img width="1460" height="328" alt="Screenshot 2026-07-22 at 10 37 14" src="https://github.com/user-attachments/assets/e4b0e8a5-9e8e-45bf-8080-260edd67709a" />

<img width="1462" height="356" alt="Screenshot 2026-07-22 at 10 42 28" src="https://github.com/user-attachments/assets/0b48f36d-4698-446e-8493-4319a65e2d01" />
